### PR TITLE
perf: Implementar Paginação nos Endpoints de Listagem da API

### DIFF
--- a/src/TCC.Contabilidade.API/Controllers/ConvitesController.cs
+++ b/src/TCC.Contabilidade.API/Controllers/ConvitesController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
+using TCC.Contabilidade.Application.DTO;
+using TCC.Contabilidade.Application.DTO.Convites;
 using TCC.Contabilidade.Application.Services;
 
 namespace TCC.Contabilidade.API.Controllers;
@@ -42,23 +44,30 @@ public class ConvitesController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<IActionResult> ListarConvites()
+    public async Task<IActionResult> ListarConvites([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
         var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier);
 
         if (userIdClaim == null)
         {
-            return Unauthorized(new
-            {
-                mensagem = "Não foi possível identificar o usuário autenticado."
-            });
+            return Unauthorized(ApiResponseDTO<object>.Fail("Não foi possível identificar o usuário autenticado.", 401));
+        }
+
+        if (page < 1 || pageSize < 1)
+        {
+            return BadRequest(ApiResponseDTO<object>.Fail("Os parâmetros de paginação devem ser maiores que zero."));
+        }
+
+        if (pageSize > 100)
+        {
+            return BadRequest(ApiResponseDTO<object>.Fail("O tamanho máximo da página é 100."));
         }
 
         var contadorId = Guid.Parse(userIdClaim.Value);
 
-        var convites = await _conviteService.GetConvitesByContadorIdAsync(contadorId);
+        var (items, metadata) = await _conviteService.GetPagedConvitesByContadorIdAsync(contadorId, page, pageSize);
 
-        return Ok(convites);
+        return Ok(ApiResponseDTO<IEnumerable<ConviteResponseDto>>.Success(items, "Convites listados com sucesso", metadata));
     }
 
     public record CriarConviteRequest(string EmailCliente);

--- a/src/TCC.Contabilidade.Application/DTO/Convites/ConviteResponseDto.cs
+++ b/src/TCC.Contabilidade.Application/DTO/Convites/ConviteResponseDto.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TCC.Contabilidade.Application.DTOs.Convites
+namespace TCC.Contabilidade.Application.DTO.Convites
 {
     public class ConviteResponseDto
     {

--- a/src/TCC.Contabilidade.Application/DTO/Empresas/EmpresaResponseDto.cs
+++ b/src/TCC.Contabilidade.Application/DTO/Empresas/EmpresaResponseDto.cs
@@ -10,7 +10,7 @@ public class EmpresaResponseDto
 {
     public Guid Id { get; set; }
 
-    public string Nome { get; set; } = string.Empty;
+    public string NomeFantasia { get; set; } = string.Empty;
 
     public string CNPJ { get; set; } = string.Empty;
 }

--- a/src/TCC.Contabilidade.Application/Interfaces/IConviteRepository.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/IConviteRepository.cs
@@ -7,6 +7,7 @@ public interface IConviteRepository
     Task AdicionarAsync(Convite convite);
     Task<Convite?> ObterPorTokenAsync(string token);
     Task<List<Convite>> GetByContadorId(Guid contadorId);
+    Task<(List<Convite> Items, int TotalCount)> GetPagedByContadorId(Guid contadorId, int page, int pageSize);
     Task SalvarAlteracoesAsync();
 }
 

--- a/src/TCC.Contabilidade.Application/Services/ConviteService.cs
+++ b/src/TCC.Contabilidade.Application/Services/ConviteService.cs
@@ -1,4 +1,6 @@
-﻿using TCC.Contabilidade.Application.Interfaces;
+using TCC.Contabilidade.Application.DTO;
+using TCC.Contabilidade.Application.DTO.Convites;
+using TCC.Contabilidade.Application.Interfaces;
 using TCC.Contabilidade.Domain.Entities;
 
 namespace TCC.Contabilidade.Application.Services;
@@ -40,5 +42,28 @@ public class ConviteService
     public async Task<List<Convite>> GetConvitesByContadorIdAsync(Guid contadorId)
     {
         return await _conviteRepository.GetByContadorId(contadorId);
+    }
+
+    public async Task<(List<ConviteResponseDto> Items, PaginationMetadataDTO Metadata)> GetPagedConvitesByContadorIdAsync(Guid contadorId, int page, int pageSize)
+    {
+        var (convites, totalCount) = await _conviteRepository.GetPagedByContadorId(contadorId, page, pageSize);
+
+        var items = convites.Select(c => new ConviteResponseDto
+        {
+            Token = c.Token,
+            EmailDestino = c.EmailCliente,
+            DataExpiracao = c.Expiracao,
+            Utilizado = c.Utilizado
+        }).ToList();
+
+        var metadata = new PaginationMetadataDTO
+        {
+            PaginaAtual = page,
+            TamanhoPagina = pageSize,
+            TotalRegistros = totalCount,
+            TotalPaginas = (int)Math.Ceiling(totalCount / (double)pageSize)
+        };
+
+        return (items, metadata);
     }
 }

--- a/src/TCC.Contabilidade.Application/Services/EmpresaService.cs
+++ b/src/TCC.Contabilidade.Application/Services/EmpresaService.cs
@@ -48,7 +48,7 @@ public class EmpresaService
         var items = empresas.Select(e => new EmpresaResponseDto
         {
             Id = e.Id,
-            Nome = e.Nome,
+            NomeFantasia = e.Nome,
             CNPJ = e.CNPJ
         }).ToList();
 

--- a/src/TCC.Contabilidade.Infrastructure/Repositories/ConviteRepository.cs
+++ b/src/TCC.Contabilidade.Infrastructure/Repositories/ConviteRepository.cs
@@ -32,6 +32,22 @@ public class ConviteRepository : IConviteRepository
             .ToListAsync();
     }
 
+    public async Task<(List<Convite> Items, int TotalCount)> GetPagedByContadorId(Guid contadorId, int page, int pageSize)
+    {
+        var query = _context.Convites
+            .AsNoTracking()
+            .Where(c => c.ContadorId == contadorId);
+
+        var totalCount = await query.CountAsync();
+
+        var items = await query
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync();
+
+        return (items, totalCount);
+    }
+
     public async Task SalvarAlteracoesAsync()
     {
         await _context.SaveChangesAsync();


### PR DESCRIPTION
Este PR implementa o suporte a paginação nos endpoints de listagem da API, conforme solicitado na issue #20.

As seguintes alterações foram realizadas:
1. **Convites**: O endpoint `GET /api/convites` agora suporta os parâmetros `page` e `pageSize`, validando-os e retornando metadados de paginação.
2. **Empresas**: O `EmpresaResponseDto` foi atualizado para usar `NomeFantasia` em vez de `Nome`, alinhando-se aos critérios de aceite e exemplos da issue.
3. **Persistência**: Foram adicionados métodos `GetPagedBy...` nos repositórios de `Empresa` e `Convite`, utilizando `AsNoTracking()`, `Skip()` e `Take()` para otimizar o desempenho.
4. **Padronização**: A estrutura de resposta foi unificada utilizando `ApiResponseDTO<T>`, garantindo consistência entre os diferentes módulos da aplicação.
5. **Arquitetura**: Namespaces de DTOs foram corrigidos para manter a consistência na camada de Aplicação.

Benefícios:
- Redução do consumo de memória em listagens extensas.
- Melhora no tempo de resposta da API.
- Escalabilidade para ambientes multi-tenant.

---
*PR created automatically by Jules for task [1731272435014137184](https://jules.google.com/task/1731272435014137184) started by @zzRonald*