### PR TITLE
sec: Implement Refresh Token flow in JWT Authentication

### DIFF
--- a/src/TCC.Contabilidade.API/Controllers/AuthController.cs
+++ b/src/TCC.Contabilidade.API/Controllers/AuthController.cs
@@ -1,8 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using TCC.Contabilidade.Application.DTO;
 using TCC.Contabilidade.Application.DTOs;
 using TCC.Contabilidade.Application.Services;
 using TCC.Contabilidade.Domain.Entities;
@@ -14,12 +11,12 @@ namespace TCC.Contabilidade.API.Controllers;
 public class AuthController : ControllerBase
 {
     private readonly UserService _userService;
-    private readonly IConfiguration _config;
+    private readonly AuthService _authService;
 
-    public AuthController(UserService userService, IConfiguration config)
+    public AuthController(UserService userService, AuthService authService)
     {
         _userService = userService;
-        _config = config;
+        _authService = authService;
     }
 
     [HttpPost("register")]
@@ -34,17 +31,17 @@ public class AuthController : ControllerBase
                 request.Perfil
             );
 
-            return Ok(new
+            return Ok(ApiResponseDTO<object>.Success(new
             {
                 usuario.Id,
                 usuario.Nome,
                 usuario.Email,
                 TipoUsuario = usuario.TipoUsuario.ToString()
-            });
+            }));
         }
         catch (Exception ex)
         {
-            return BadRequest(new { message = ex.Message });
+            return BadRequest(ApiResponseDTO<object>.Fail(ex.Message));
         }
     }
 
@@ -61,73 +58,49 @@ public class AuthController : ControllerBase
                 request.Senha
             );
 
-            return Ok(new
+            return Ok(ApiResponseDTO<object>.Success(new
             {
-                message = "Cliente registrado com sucesso",
                 user.Id,
                 user.Email
-            });
+            }, "Cliente registrado com sucesso"));
         }
         catch (Exception ex)
         {
-            return BadRequest(new
-            {
-                message = ex.Message
-            });
+            return BadRequest(ApiResponseDTO<object>.Fail(ex.Message));
         }
     }
 
     [HttpPost("login")]
     public async Task<IActionResult> Login([FromBody] LoginRequest request)
     {
-        var usuario = await _userService.AuthenticateAsync(request.Email, request.Senha);
+        var response = await _authService.LoginAsync(request.Email, request.Senha);
 
-        if (usuario == null)
-            return Unauthorized(new { message = "Email ou senha inválidos" });
+        if (response == null)
+            return Unauthorized(ApiResponseDTO<object>.Fail("Email ou senha inválidos", 401));
 
-        var token = GenerateJwtToken(usuario);
-
-        return Ok(new
-        {
-            token,
-            usuario = new
-            {
-                usuario.Id,
-                usuario.Nome,
-                usuario.Email,
-                TipoUsuario = usuario.TipoUsuario.ToString()
-            }
-        });
+        return Ok(ApiResponseDTO<AuthResponseDTO>.Success(response));
     }
 
-    private string GenerateJwtToken(User usuario)
+    [HttpPost("refresh-token")]
+    public async Task<IActionResult> RefreshToken([FromBody] RefreshTokenRequest request)
     {
-        var key = Encoding.ASCII.GetBytes(
-            _config["JwtKey"] ?? "MinhaChaveSuperSecretaParaJWT_ChangeThis"
-        );
+        var response = await _authService.RefreshTokenAsync(request.RefreshToken);
 
-        var tokenHandler = new JwtSecurityTokenHandler();
+        if (response == null)
+            return Unauthorized(ApiResponseDTO<object>.Fail("Refresh Token inválido ou expirado", 401));
 
-        var tokenDescriptor = new SecurityTokenDescriptor
-        {
-            Subject = new ClaimsIdentity(new Claim[]
-            {
-                new Claim(ClaimTypes.NameIdentifier, usuario.Id.ToString()),
-                new Claim(ClaimTypes.Name, usuario.Nome),
-                new Claim(ClaimTypes.Role, usuario.TipoUsuario.ToString())
-            }),
+        return Ok(ApiResponseDTO<AuthResponseDTO>.Success(response));
+    }
 
-            Expires = DateTime.UtcNow.AddHours(4),
+    [HttpPost("revoke-token")]
+    public async Task<IActionResult> RevokeToken([FromBody] RevokeTokenRequest request)
+    {
+        var result = await _authService.RevokeTokenAsync(request.Token);
 
-            SigningCredentials = new SigningCredentials(
-                new SymmetricSecurityKey(key),
-                SecurityAlgorithms.HmacSha256Signature
-            )
-        };
+        if (!result)
+            return BadRequest(ApiResponseDTO<object>.Fail("Token inválido ou já revogado"));
 
-        var token = tokenHandler.CreateToken(tokenDescriptor);
-
-        return tokenHandler.WriteToken(token);
+        return Ok(ApiResponseDTO<object>.Success(null, "Token revogado com sucesso"));
     }
 
     public record RegisterRequest(string Nome, string Email, string Senha, string Perfil);

--- a/src/TCC.Contabilidade.API/Program.cs
+++ b/src/TCC.Contabilidade.API/Program.cs
@@ -79,8 +79,11 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 builder.Services.AddScoped<IUsuarioRepository, UsuarioRepository>();
 builder.Services.AddScoped<IConviteRepository, ConviteRepository>();
 builder.Services.AddScoped<ICompanyConfigRepository, CompanyConfigRepository>();
+builder.Services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
 
+builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<UserService>();
+builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<ConviteService>();
 builder.Services.AddScoped<CompanyConfigService>();
 

--- a/src/TCC.Contabilidade.Application/DTO/AuthDTO.cs
+++ b/src/TCC.Contabilidade.Application/DTO/AuthDTO.cs
@@ -1,0 +1,27 @@
+namespace TCC.Contabilidade.Application.DTO;
+
+public class AuthResponseDTO
+{
+    public string AccessToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public int ExpiraEm { get; set; } // Em segundos
+    public UserResponseDTO Usuario { get; set; } = new();
+}
+
+public class UserResponseDTO
+{
+    public Guid Id { get; set; }
+    public string Nome { get; set; } = string.Empty;
+    public string Email { get; set; } = string.Empty;
+    public string TipoUsuario { get; set; } = string.Empty;
+}
+
+public class RefreshTokenRequest
+{
+    public string RefreshToken { get; set; } = string.Empty;
+}
+
+public class RevokeTokenRequest
+{
+    public string Token { get; set; } = string.Empty;
+}

--- a/src/TCC.Contabilidade.Application/Interfaces/IRefreshTokenRepository.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/IRefreshTokenRepository.cs
@@ -1,0 +1,11 @@
+using TCC.Contabilidade.Domain.Entities;
+
+namespace TCC.Contabilidade.Application.Interfaces;
+
+public interface IRefreshTokenRepository
+{
+    Task<RefreshToken?> ObterPorTokenAsync(string token);
+    Task AdicionarAsync(RefreshToken refreshToken);
+    Task AtualizarAsync(RefreshToken refreshToken);
+    Task SalvarAlteracoesAsync();
+}

--- a/src/TCC.Contabilidade.Application/Interfaces/ITokenService.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/ITokenService.cs
@@ -1,0 +1,9 @@
+using TCC.Contabilidade.Domain.Entities;
+
+namespace TCC.Contabilidade.Application.Interfaces;
+
+public interface ITokenService
+{
+    string GenerateAccessToken(User usuario);
+    string GenerateRefreshToken();
+}

--- a/src/TCC.Contabilidade.Application/Services/AuthService.cs
+++ b/src/TCC.Contabilidade.Application/Services/AuthService.cs
@@ -1,0 +1,91 @@
+using TCC.Contabilidade.Application.DTO;
+using TCC.Contabilidade.Application.Interfaces;
+using TCC.Contabilidade.Domain.Entities;
+
+namespace TCC.Contabilidade.Application.Services;
+
+public class AuthService
+{
+    private readonly IUsuarioRepository _usuarioRepository;
+    private readonly IRefreshTokenRepository _refreshTokenRepository;
+    private readonly ITokenService _tokenService;
+
+    public AuthService(
+        IUsuarioRepository usuarioRepository,
+        IRefreshTokenRepository refreshTokenRepository,
+        ITokenService tokenService)
+    {
+        _usuarioRepository = usuarioRepository;
+        _refreshTokenRepository = refreshTokenRepository;
+        _tokenService = tokenService;
+    }
+
+    public async Task<AuthResponseDTO?> LoginAsync(string email, string senha)
+    {
+        var usuario = await _usuarioRepository.ObterPorEmailAsync(email);
+
+        if (usuario == null || !BCrypt.Net.BCrypt.Verify(senha, usuario.SenhaHash))
+            return null;
+
+        return await GenerateAuthResponseAsync(usuario);
+    }
+
+    public async Task<AuthResponseDTO?> RefreshTokenAsync(string token)
+    {
+        var refreshToken = await _refreshTokenRepository.ObterPorTokenAsync(token);
+
+        if (refreshToken == null || !refreshToken.IsAtivo)
+            return null;
+
+        // Revoga o token atual
+        refreshToken.RevogadoEm = DateTime.UtcNow;
+        await _refreshTokenRepository.AtualizarAsync(refreshToken);
+
+        // Gera novos tokens
+        return await GenerateAuthResponseAsync(refreshToken.Usuario!);
+    }
+
+    public async Task<bool> RevokeTokenAsync(string token)
+    {
+        var refreshToken = await _refreshTokenRepository.ObterPorTokenAsync(token);
+
+        if (refreshToken == null || !refreshToken.IsAtivo)
+            return false;
+
+        refreshToken.RevogadoEm = DateTime.UtcNow;
+        await _refreshTokenRepository.AtualizarAsync(refreshToken);
+        await _refreshTokenRepository.SalvarAlteracoesAsync();
+
+        return true;
+    }
+
+    private async Task<AuthResponseDTO> GenerateAuthResponseAsync(User usuario)
+    {
+        var accessToken = _tokenService.GenerateAccessToken(usuario);
+        var refreshTokenStr = _tokenService.GenerateRefreshToken();
+
+        var refreshToken = new RefreshToken
+        {
+            Token = refreshTokenStr,
+            UsuarioId = usuario.Id,
+            ExpiraEm = DateTime.UtcNow.AddDays(7)
+        };
+
+        await _refreshTokenRepository.AdicionarAsync(refreshToken);
+        await _refreshTokenRepository.SalvarAlteracoesAsync();
+
+        return new AuthResponseDTO
+        {
+            AccessToken = accessToken,
+            RefreshToken = refreshTokenStr,
+            ExpiraEm = 900, // 15 minutos em segundos
+            Usuario = new UserResponseDTO
+            {
+                Id = usuario.Id,
+                Nome = usuario.Nome,
+                Email = usuario.Email,
+                TipoUsuario = usuario.TipoUsuario.ToString()
+            }
+        };
+    }
+}

--- a/src/TCC.Contabilidade.Application/Services/TokenService.cs
+++ b/src/TCC.Contabilidade.Application/Services/TokenService.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using TCC.Contabilidade.Application.Interfaces;
+using TCC.Contabilidade.Domain.Entities;
+
+namespace TCC.Contabilidade.Application.Services;
+
+public class TokenService : ITokenService
+{
+    private readonly IConfiguration _config;
+
+    public TokenService(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public string GenerateAccessToken(User usuario)
+    {
+        var key = Encoding.ASCII.GetBytes(
+            _config["Jwt:Key"] ?? "MinhaChaveSuperSecretaParaJWT_ChangeThis"
+        );
+
+        var tokenHandler = new JwtSecurityTokenHandler();
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new Claim[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, usuario.Id.ToString()),
+                new Claim(ClaimTypes.Name, usuario.Nome),
+                new Claim(ClaimTypes.Role, usuario.TipoUsuario.ToString())
+            }),
+
+            Expires = DateTime.UtcNow.AddMinutes(15), // Reduzido conforme objetivo
+
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(key),
+                SecurityAlgorithms.HmacSha256Signature
+            )
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+
+        return tokenHandler.WriteToken(token);
+    }
+
+    public string GenerateRefreshToken()
+    {
+        var randomNumber = new byte[32];
+        using var rng = RandomNumberGenerator.Create();
+        rng.GetBytes(randomNumber);
+        return Convert.ToBase64String(randomNumber);
+    }
+}

--- a/src/TCC.Contabilidade.Application/TCC.Contabilidade.Application.csproj
+++ b/src/TCC.Contabilidade.Application/TCC.Contabilidade.Application.csproj
@@ -2,6 +2,9 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/TCC.Contabilidade.Domain/Entities/RefreshToken.cs
+++ b/src/TCC.Contabilidade.Domain/Entities/RefreshToken.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace TCC.Contabilidade.Domain.Entities;
+
+public class RefreshToken
+{
+    public Guid Id { get; set; }
+    public string Token { get; set; } = string.Empty;
+    public Guid UsuarioId { get; set; }
+    public User? Usuario { get; set; }
+    public DateTime ExpiraEm { get; set; }
+    public DateTime CriadoEm { get; set; }
+    public DateTime? RevogadoEm { get; set; }
+
+    public bool IsExpirado => DateTime.UtcNow >= ExpiraEm;
+    public bool IsAtivo => RevogadoEm == null && !IsExpirado;
+
+    public RefreshToken()
+    {
+        Id = Guid.NewGuid();
+        CriadoEm = DateTime.UtcNow;
+    }
+}

--- a/src/TCC.Contabilidade.Domain/Entities/User.cs
+++ b/src/TCC.Contabilidade.Domain/Entities/User.cs
@@ -26,6 +26,8 @@ public class User
 
     public ICollection<UsuarioEmpresa> UsuariosEmpresas { get; set; } = new List<UsuarioEmpresa>();
 
+    public ICollection<RefreshToken> RefreshTokens { get; set; } = new List<RefreshToken>();
+
     public User() { }
 
     public User(string nome, string email, string senhaHash, TipoUsuario tipoUsuario)

--- a/src/TCC.Contabilidade.Infrastructure/Data/AppDbContext.cs
+++ b/src/TCC.Contabilidade.Infrastructure/Data/AppDbContext.cs
@@ -20,6 +20,8 @@ public class AppDbContext : DbContext
 
     public DbSet<CompanyConfig> CompanyConfigs { get; set; }
 
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
@@ -101,6 +103,23 @@ public class AppDbContext : DbContext
                 .WithOne(e => e.Config)
                 .HasForeignKey<CompanyConfig>(c => c.EmpresaId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<RefreshToken>(entity =>
+        {
+            entity.HasKey(rt => rt.Id);
+
+            entity.Property(rt => rt.Token)
+                .IsRequired()
+                .HasMaxLength(200);
+
+            entity.HasOne(rt => rt.Usuario)
+                .WithMany(u => u.RefreshTokens)
+                .HasForeignKey(rt => rt.UsuarioId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasIndex(rt => rt.Token)
+                .IsUnique();
         });
     }
 }

--- a/src/TCC.Contabilidade.Infrastructure/Repositories/RefreshTokenRepository.cs
+++ b/src/TCC.Contabilidade.Infrastructure/Repositories/RefreshTokenRepository.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using TCC.Contabilidade.Application.Interfaces;
+using TCC.Contabilidade.Domain.Entities;
+using TCC.Contabilidade.Infrastructure.Data;
+
+namespace TCC.Contabilidade.Infrastructure.Repositories;
+
+public class RefreshTokenRepository : IRefreshTokenRepository
+{
+    private readonly AppDbContext _context;
+
+    public RefreshTokenRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<RefreshToken?> ObterPorTokenAsync(string token)
+    {
+        return await _context.RefreshTokens
+            .Include(rt => rt.Usuario)
+            .FirstOrDefaultAsync(rt => rt.Token == token);
+    }
+
+    public async Task AdicionarAsync(RefreshToken refreshToken)
+    {
+        await _context.RefreshTokens.AddAsync(refreshToken);
+    }
+
+    public async Task AtualizarAsync(RefreshToken refreshToken)
+    {
+        _context.RefreshTokens.Update(refreshToken);
+        await Task.CompletedTask;
+    }
+
+    public async Task SalvarAlteracoesAsync()
+    {
+        await _context.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
This PR implements the Refresh Token mechanism in the JWT authentication flow.

Key changes:
1. **Domain Layer**: Added `RefreshToken` entity and updated `User` entity with a collection of refresh tokens.
2. **Infrastructure Layer**: Added `RefreshTokenRepository` and updated `AppDbContext` with the new entity configuration.
3. **Application Layer**: 
   - Created `AuthResponseDTO`, `RefreshTokenRequest`, and `RevokeTokenRequest`.
   - Implemented `ITokenService` and `TokenService` to abstract token generation.
   - Implemented `AuthService` to centralize authentication logic, including login, token refresh (with rotation), and revocation.
4. **API Layer**:
   - Updated `AuthController` to use the new `AuthService`.
   - Added `POST /api/auth/refresh-token` and `POST /api/auth/revoke-token` endpoints.
   - Standardized all responses using `ApiResponseDTO<T>`.

Security Improvements:
- Access Token lifespan reduced to 15 minutes.
- Refresh Token rotation implemented: every time a refresh token is used, it is revoked and a new one is issued.
- Refresh Tokens are generated using a cryptographically secure random number generator.

Closes #22

---
*PR created automatically by Jules for task [9002174457672689314](https://jules.google.com/task/9002174457672689314) started by @zzRonald*