### PR TITLE
perf: Implementar Camada de Cache para Endpoints da API

### DIFF
--- a/src/TCC.Contabilidade.API/Program.cs
+++ b/src/TCC.Contabilidade.API/Program.cs
@@ -6,6 +6,7 @@ using System.Text;
 using TCC.Contabilidade.API.Middlewares;
 using TCC.Contabilidade.Application.Interfaces;
 using TCC.Contabilidade.Application.Services;
+using TCC.Contabilidade.Infrastructure.Cache;
 using TCC.Contabilidade.Infrastructure.Data;
 using TCC.Contabilidade.Infrastructure.Integrations;
 using TCC.Contabilidade.Infrastructure.Repositories;
@@ -102,6 +103,10 @@ builder.Services.AddScoped<IntegrationService>();
 
 // TENANT CONTEXT
 builder.Services.AddScoped<ITenantContext, TenantContextService>();
+
+// CACHE
+builder.Services.AddSingleton<ICacheService, MemoryCacheProvider>();
+builder.Services.AddSingleton<CacheService>();
 
 
 // =============================

--- a/src/TCC.Contabilidade.Application/Interfaces/ICacheService.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/ICacheService.cs
@@ -1,0 +1,8 @@
+namespace TCC.Contabilidade.Application.Interfaces;
+
+public interface ICacheService
+{
+    Task<T?> GetAsync<T>(string key);
+    Task SetAsync<T>(string key, T value, TimeSpan? expiration = null);
+    Task RemoveAsync(string key);
+}

--- a/src/TCC.Contabilidade.Application/Services/CacheService.cs
+++ b/src/TCC.Contabilidade.Application/Services/CacheService.cs
@@ -1,0 +1,50 @@
+using TCC.Contabilidade.Application.Interfaces;
+
+namespace TCC.Contabilidade.Application.Services;
+
+public class CacheService
+{
+    private readonly ICacheService _cacheProvider;
+
+    public CacheService(ICacheService cacheProvider)
+    {
+        _cacheProvider = cacheProvider;
+    }
+
+    public async Task<T?> GetAsync<T>(string key)
+    {
+        return await _cacheProvider.GetAsync<T>(key);
+    }
+
+    public async Task SetAsync<T>(string key, T value, TimeSpan? expiration = null)
+    {
+        await _cacheProvider.SetAsync(key, value, expiration);
+    }
+
+    public async Task RemoveAsync(string key)
+    {
+        await _cacheProvider.RemoveAsync(key);
+    }
+
+    public string GenerateKey(string prefix, params object[] args)
+    {
+        return $"{prefix}:{string.Join(":", args)}";
+    }
+
+    public async Task<T?> GetOrCreateAsync<T>(string key, Func<Task<T>> factory, TimeSpan? expiration = null)
+    {
+        var cachedValue = await GetAsync<T>(key);
+        if (cachedValue != null)
+        {
+            return cachedValue;
+        }
+
+        var newValue = await factory();
+        if (newValue != null)
+        {
+            await SetAsync(key, newValue, expiration);
+        }
+
+        return newValue;
+    }
+}

--- a/src/TCC.Contabilidade.Application/Services/CnpjService.cs
+++ b/src/TCC.Contabilidade.Application/Services/CnpjService.cs
@@ -7,10 +7,13 @@ namespace TCC.Contabilidade.Application.Services;
 public class CnpjService
 {
     private readonly ICnpjApiClient _client;
+    private readonly CacheService _cache;
+    private const string CachePrefix = "cnpj";
 
-    public CnpjService(ICnpjApiClient client)
+    public CnpjService(ICnpjApiClient client, CacheService cache)
     {
         _client = client;
+        _cache = cache;
     }
 
     public async Task<CnpjResponseDTO> ConsultarCnpj(string cnpj, TipoUsuario tipoUsuario)
@@ -26,8 +29,13 @@ public class CnpjService
         if (cnpj.Length != 14)
             throw new Exception("CNPJ inválido");
 
-        //  Consulta API externa
-        var result = await _client.ConsultarCnpj(cnpj);
+        string cacheKey = _cache.GenerateKey(CachePrefix, cnpj);
+
+        //  Consulta API externa com cache
+        var result = await _cache.GetOrCreateAsync(cacheKey, async () =>
+        {
+            return await _client.ConsultarCnpj(cnpj);
+        }, TimeSpan.FromHours(2));
 
         if (result == null)
             throw new Exception("CNPJ não encontrado");

--- a/src/TCC.Contabilidade.Application/Services/CompanyConfigService.cs
+++ b/src/TCC.Contabilidade.Application/Services/CompanyConfigService.cs
@@ -8,32 +8,40 @@ public class CompanyConfigService
 {
     private readonly ICompanyConfigRepository _repository;
     private readonly IEmpresaRepository _empresaRepository;
+    private readonly CacheService _cache;
+    private const string CachePrefix = "company_config";
 
-    public CompanyConfigService(ICompanyConfigRepository repository, IEmpresaRepository empresaRepository)
+    public CompanyConfigService(ICompanyConfigRepository repository, IEmpresaRepository empresaRepository, CacheService cache)
     {
         _repository = repository;
         _empresaRepository = empresaRepository;
+        _cache = cache;
     }
 
     public async Task<CompanyConfigDTO> GetByEmpresaId(Guid empresaId, Guid usuarioId)
     {
         await ValidateUserAccess(empresaId, usuarioId);
 
-        var config = await _repository.GetByEmpresaId(empresaId);
+        string cacheKey = _cache.GenerateKey(CachePrefix, empresaId);
 
-        if (config == null)
+        return await _cache.GetOrCreateAsync(cacheKey, async () =>
         {
-            return new CompanyConfigDTO
-            {
-                EmpresaId = empresaId,
-                MoedaPadrao = "BRL",
-                FormatoData = "dd/MM/yyyy",
-                Timezone = "America/Sao_Paulo",
-                NotificacoesEmail = true
-            };
-        }
+            var config = await _repository.GetByEmpresaId(empresaId);
 
-        return MapToDto(config);
+            if (config == null)
+            {
+                return new CompanyConfigDTO
+                {
+                    EmpresaId = empresaId,
+                    MoedaPadrao = "BRL",
+                    FormatoData = "dd/MM/yyyy",
+                    Timezone = "America/Sao_Paulo",
+                    NotificacoesEmail = true
+                };
+            }
+
+            return MapToDto(config);
+        }, TimeSpan.FromMinutes(30)) ?? new CompanyConfigDTO();
     }
 
     public async Task Upsert(CompanyConfigDTO dto, Guid usuarioId)
@@ -63,6 +71,8 @@ public class CompanyConfigService
             config.NotificacoesEmail = dto.NotificacoesEmail;
             await _repository.UpdateAsync(config);
         }
+
+        await _cache.RemoveAsync(_cache.GenerateKey(CachePrefix, dto.EmpresaId));
     }
 
     private async Task ValidateUserAccess(Guid empresaId, Guid usuarioId)

--- a/src/TCC.Contabilidade.Application/Services/EmpresaService.cs
+++ b/src/TCC.Contabilidade.Application/Services/EmpresaService.cs
@@ -9,11 +9,14 @@ public class EmpresaService
 {
     private readonly IEmpresaRepository _repository;
     private readonly AuditService _auditService;
+    private readonly CacheService _cache;
+    private const string CachePrefix = "empresas";
 
-    public EmpresaService(IEmpresaRepository repository, AuditService auditService)
+    public EmpresaService(IEmpresaRepository repository, AuditService auditService, CacheService cache)
     {
         _repository = repository;
         _auditService = auditService;
+        _cache = cache;
     }
 
     public async Task Create(CreateEmpresaDto dto, Guid usuarioId)
@@ -43,28 +46,39 @@ public class EmpresaService
         }
 
         await _auditService.RegistrarEvento("CREATE_EMPRESA", "Empresa", empresa.Id.ToString(), usuarioId);
+        await InvalidateUserCache(usuarioId);
     }
 
     public async Task<(List<EmpresaResponseDto> Items, PaginationMetadataDTO Metadata)> GetAll(Guid usuarioId, int page, int pageSize)
     {
-        var (empresas, totalCount) = await _repository.GetPagedByUsuarioId(usuarioId, page, pageSize);
+        string versionKey = _cache.GenerateKey(CachePrefix, usuarioId, "version");
+        string version = await _cache.GetOrCreateAsync(versionKey, () => Task.FromResult(Guid.NewGuid().ToString()), TimeSpan.FromHours(1)) ?? "1";
 
-        var items = empresas.Select(e => new EmpresaResponseDto
+        string cacheKey = _cache.GenerateKey(CachePrefix, usuarioId, version, page, pageSize);
+
+        var cached = await _cache.GetOrCreateAsync(cacheKey, async () =>
         {
-            Id = e.Id,
-            NomeFantasia = e.Nome,
-            CNPJ = e.CNPJ
-        }).ToList();
+            var (empresas, totalCount) = await _repository.GetPagedByUsuarioId(usuarioId, page, pageSize);
 
-        var metadata = new PaginationMetadataDTO
-        {
-            PaginaAtual = page,
-            TamanhoPagina = pageSize,
-            TotalRegistros = totalCount,
-            TotalPaginas = (int)Math.Ceiling(totalCount / (double)pageSize)
-        };
+            var items = empresas.Select(e => new EmpresaResponseDto
+            {
+                Id = e.Id,
+                NomeFantasia = e.Nome,
+                CNPJ = e.CNPJ
+            }).ToList();
 
-        return (items, metadata);
+            var metadata = new PaginationMetadataDTO
+            {
+                PaginaAtual = page,
+                TamanhoPagina = pageSize,
+                TotalRegistros = totalCount,
+                TotalPaginas = (int)Math.Ceiling(totalCount / (double)pageSize)
+            };
+
+            return new EmpresaListResponse { Items = items, Metadata = metadata };
+        }, TimeSpan.FromMinutes(5));
+
+        return (cached?.Items ?? new List<EmpresaResponseDto>(), cached?.Metadata ?? new PaginationMetadataDTO());
     }
 
     public async Task Update(Guid id, UpdateEmpresaDto dto, Guid usuarioId)
@@ -87,6 +101,7 @@ public class EmpresaService
         await _repository.Update(empresa);
 
         await _auditService.RegistrarEvento("UPDATE_EMPRESA", "Empresa", id.ToString(), usuarioId);
+        await InvalidateUserCache(usuarioId);
     }
 
     public async Task Delete(Guid id, Guid usuarioId)
@@ -102,5 +117,18 @@ public class EmpresaService
         await _repository.Delete(empresa);
 
         await _auditService.RegistrarEvento("EXCLUSAO_EMPRESA", "Empresa", id.ToString(), usuarioId);
+        await InvalidateUserCache(usuarioId);
+    }
+
+    private async Task InvalidateUserCache(Guid usuarioId)
+    {
+        // Invalida a versão do cache para o usuário, forçando novas consultas
+        await _cache.RemoveAsync(_cache.GenerateKey(CachePrefix, usuarioId, "version"));
+    }
+
+    private class EmpresaListResponse
+    {
+        public List<EmpresaResponseDto> Items { get; set; } = new();
+        public PaginationMetadataDTO Metadata { get; set; } = new();
     }
 }

--- a/src/TCC.Contabilidade.Infrastructure/Cache/MemoryCacheProvider.cs
+++ b/src/TCC.Contabilidade.Infrastructure/Cache/MemoryCacheProvider.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Caching.Memory;
+using TCC.Contabilidade.Application.Interfaces;
+
+namespace TCC.Contabilidade.Infrastructure.Cache;
+
+public class MemoryCacheProvider : ICacheService
+{
+    private readonly IMemoryCache _cache;
+
+    public MemoryCacheProvider(IMemoryCache cache)
+    {
+        _cache = cache;
+    }
+
+    public Task<T?> GetAsync<T>(string key)
+    {
+        _cache.TryGetValue(key, out T? value);
+        return Task.FromResult(value);
+    }
+
+    public Task SetAsync<T>(string key, T value, TimeSpan? expiration = null)
+    {
+        var options = new MemoryCacheEntryOptions();
+        if (expiration.HasValue)
+        {
+            options.AbsoluteExpirationRelativeToNow = expiration;
+        }
+
+        _cache.Set(key, value, options);
+        return Task.CompletedTask;
+    }
+
+    public Task RemoveAsync(string key)
+    {
+        _cache.Remove(key);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Este PR implementa uma camada de cache robusta para os endpoints da API, visando reduzir a carga no banco de dados e melhorar o tempo de resposta.

### Alterações Realizadas:
1.  **Infraestrutura de Cache:**
    *   `ICacheService`: Interface abstrata para operações de cache.
    *   `MemoryCacheProvider`: Implementação concreta utilizando `IMemoryCache`.
    *   `CacheService`: Serviço de aplicação que facilita a geração de chaves e o padrão "Get or Create".
2.  **Otimização de Endpoints:**
    *   **Empresas:** Implementado cache no `GetAll` com uma estratégia de **versionamento por usuário**. Ao criar, editar ou excluir uma empresa, a versão do cache do usuário é invalidada, limpando todas as páginas de uma só vez.
    *   **Consulta CNPJ:** Resultados de APIs externas agora são cacheados por 2 horas.
    *   **Configurações:** Configurações da empresa cacheadas por 30 minutos, com invalidação automática no `Upsert`.
3.  **Configuração de DI:**
    *   Serviços registrados como `Singleton` no `Program.cs` para máxima eficiência.

Closes #26

---
*PR created automatically by Jules for task [11791957483640232329](https://jules.google.com/task/11791957483640232329) started by @zzRonald*