### PR TITLE
[Seg] Políticas de CORS e Segurança de Cabeçalhos

### DIFF
--- a/src/TCC.Contabilidade.API/Middlewares/SecurityHeadersMiddleware.cs
+++ b/src/TCC.Contabilidade.API/Middlewares/SecurityHeadersMiddleware.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace TCC.Contabilidade.API.Middlewares
+{
+    public class SecurityHeadersMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public SecurityHeadersMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            // X-Frame-Options: Evita clickjacking ao proibir que a página seja exibida em frames/iframes
+            context.Response.Headers["X-Frame-Options"] = "DENY";
+
+            // X-Content-Type-Options: Evita que o navegador tente adivinhar o tipo de conteúdo (MIME sniffing)
+            context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+
+            // Referrer-Policy: Controla quais informações de referência são enviadas em requisições
+            context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+
+            // X-XSS-Protection: Ativa o filtro de Cross-site Scripting (XSS) nos navegadores
+            context.Response.Headers["X-XSS-Protection"] = "1; mode=block";
+
+            // Content-Security-Policy: Controla quais recursos podem ser carregados no navegador
+            // Configuração que permite o funcionamento do Swagger (necessita de unsafe-inline para o UI)
+            context.Response.Headers["Content-Security-Policy"] =
+                "default-src 'self'; " +
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
+                "style-src 'self' 'unsafe-inline'; " +
+                "img-src 'self' data:; " +
+                "font-src 'self'; " +
+                "connect-src 'self';";
+
+            await _next(context);
+        }
+    }
+}

--- a/src/TCC.Contabilidade.API/Program.cs
+++ b/src/TCC.Contabilidade.API/Program.cs
@@ -119,6 +119,26 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<IRateLimitService, RateLimitService>();
 
+// =============================
+// CORS CONFIG
+// =============================
+
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("DefaultPolicy", policy =>
+    {
+        if (allowedOrigins.Length > 0)
+        {
+            policy.WithOrigins(allowedOrigins)
+                  .AllowAnyHeader()
+                  .AllowAnyMethod()
+                  .AllowCredentials();
+        }
+    });
+});
+
 
 // =============================
 // SWAGGER + JWT
@@ -166,6 +186,8 @@ var app = builder.Build();
 // MIDDLEWARE
 // =============================
 
+app.UseMiddleware<SecurityHeadersMiddleware>();
+
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
@@ -174,6 +196,7 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+app.UseCors("DefaultPolicy");
 
 app.UseAuthentication();
 app.UseMiddleware<ExceptionMiddleware>();

--- a/src/TCC.Contabilidade.API/appsettings.Development.json
+++ b/src/TCC.Contabilidade.API/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:3000",
+      "http://localhost:5173"
+    ]
   }
 }

--- a/src/TCC.Contabilidade.API/appsettings.json
+++ b/src/TCC.Contabilidade.API/appsettings.json
@@ -10,5 +10,8 @@
     }
   },
 
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Cors": {
+    "AllowedOrigins": []
+  }
 }


### PR DESCRIPTION
Esta PR implementa as políticas de CORS e os cabeçalhos de segurança HTTP conforme solicitado na issue #47.

### Mudanças principais:
1. **SecurityHeadersMiddleware**: Novo middleware que adiciona cabeçalhos de segurança essenciais (`X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `X-XSS-Protection` e uma `Content-Security-Policy` compatível com Swagger).
2. **CORS**: Configurado para ler origens permitidas do `appsettings.json`. No ambiente de desenvolvimento, permite `http://localhost:3000` e `http://localhost:5173`. Em produção, por padrão, não permite origens a menos que configurado (secure-by-default).
3. **Program.cs**: Registro da política de CORS e inclusão dos middlewares no início do pipeline para garantir proteção em todas as respostas.

### Validação:
- O projeto compila sem erros (`dotnet build`).
- Testes com `curl` confirmaram a presença de todos os cabeçalhos de segurança.
- Testes de CORS confirmaram que origens não autorizadas são bloqueadas e as autorizadas recebem os cabeçalhos corretos (`Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`).

Closes #47

---
*PR created automatically by Jules for task [9672889298354302892](https://jules.google.com/task/9672889298354302892) started by @zzRonald*