### PR TITLE
feat: Dashboard e Relatórios Gerenciais

### DIFF
--- a/src/TCC.Contabilidade.API/Controllers/DashboardController.cs
+++ b/src/TCC.Contabilidade.API/Controllers/DashboardController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using TCC.Contabilidade.Application.DTO;
+using TCC.Contabilidade.Application.Interfaces;
+
+namespace TCC.Contabilidade.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Roles = "Contador,Admin")]
+public class DashboardController : ControllerBase
+{
+    private readonly IDashboardService _dashboardService;
+
+    public DashboardController(IDashboardService dashboardService)
+    {
+        _dashboardService = dashboardService;
+    }
+
+    [HttpGet("resumo")]
+    public async Task<ActionResult<ApiResponseDTO<DashboardSummaryDTO>>> GetResumo()
+    {
+        var usuarioIdStr = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (string.IsNullOrEmpty(usuarioIdStr) || !Guid.TryParse(usuarioIdStr, out var usuarioId))
+        {
+            return BadRequest(ApiResponseDTO<DashboardSummaryDTO>.Fail("Usuário não identificado."));
+        }
+
+        var resumo = await _dashboardService.GetResumoAsync(usuarioId);
+
+        return Ok(ApiResponseDTO<DashboardSummaryDTO>.Success(resumo));
+    }
+}

--- a/src/TCC.Contabilidade.API/Program.cs
+++ b/src/TCC.Contabilidade.API/Program.cs
@@ -90,6 +90,7 @@ builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<ConviteService>();
 builder.Services.AddScoped<CompanyConfigService>();
 builder.Services.AddScoped<AuditService>();
+builder.Services.AddScoped<IDashboardService, DashboardService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<IEmailService, EmailService>();
 

--- a/src/TCC.Contabilidade.Application/DTO/DashboardSummaryDTO.cs
+++ b/src/TCC.Contabilidade.Application/DTO/DashboardSummaryDTO.cs
@@ -1,0 +1,27 @@
+namespace TCC.Contabilidade.Application.DTO;
+
+/// <summary>
+/// DTO que representa o resumo dos indicadores para o dashboard.
+/// </summary>
+public class DashboardSummaryDTO
+{
+    /// <summary>
+    /// Total de empresas vinculadas ao usuário.
+    /// </summary>
+    public int TotalEmpresas { get; set; }
+
+    /// <summary>
+    /// Total de clientes (usuários) vinculados ao contador.
+    /// </summary>
+    public int TotalUsuarios { get; set; }
+
+    /// <summary>
+    /// Quantidade de convites pendentes e não expirados.
+    /// </summary>
+    public int ConvitesPendentes { get; set; }
+
+    /// <summary>
+    /// Lista das atividades recentes registradas na auditoria para o usuário.
+    /// </summary>
+    public List<AuditLogResponseDTO> AtividadesRecentes { get; set; } = new();
+}

--- a/src/TCC.Contabilidade.Application/Interfaces/IConviteRepository.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/IConviteRepository.cs
@@ -9,6 +9,7 @@ public interface IConviteRepository
     Task<List<Convite>> GetByContadorId(Guid contadorId);
     Task<(List<Convite> Items, int TotalCount)> GetPagedByContadorId(Guid contadorId, int page, int pageSize);
     Task SalvarAlteracoesAsync();
+    Task<int> CountPendentesByContadorId(Guid contadorId);
 }
 
    

--- a/src/TCC.Contabilidade.Application/Interfaces/IDashboardService.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/IDashboardService.cs
@@ -1,0 +1,8 @@
+using TCC.Contabilidade.Application.DTO;
+
+namespace TCC.Contabilidade.Application.Interfaces;
+
+public interface IDashboardService
+{
+    Task<DashboardSummaryDTO> GetResumoAsync(Guid usuarioId);
+}

--- a/src/TCC.Contabilidade.Application/Interfaces/IEmpresaRepository.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/IEmpresaRepository.cs
@@ -23,4 +23,6 @@ public interface IEmpresaRepository
     Task AddUsuarioEmpresaAsync(UsuarioEmpresa usuarioEmpresa);
 
     Task<bool> IsUsuarioVinculadoAsync(Guid usuarioId, Guid empresaId);
+
+    Task<int> CountByUsuarioId(Guid usuarioId);
 }

--- a/src/TCC.Contabilidade.Application/Interfaces/IUsuarioRepository.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/IUsuarioRepository.cs
@@ -9,4 +9,5 @@ public interface IUsuarioRepository
     Task AdicionarAsync(User usuario);
     Task AtualizarAsync(User usuario);
     Task SalvarAlteracoesAsync();
+    Task<int> CountClientesByContadorId(Guid contadorId);
 }

--- a/src/TCC.Contabilidade.Application/Services/DashboardService.cs
+++ b/src/TCC.Contabilidade.Application/Services/DashboardService.cs
@@ -1,0 +1,46 @@
+using TCC.Contabilidade.Application.DTO;
+using TCC.Contabilidade.Application.Interfaces;
+
+namespace TCC.Contabilidade.Application.Services;
+
+public class DashboardService : IDashboardService
+{
+    private readonly IEmpresaRepository _empresaRepository;
+    private readonly IUsuarioRepository _usuarioRepository;
+    private readonly IConviteRepository _conviteRepository;
+    private readonly IAuditRepository _auditRepository;
+
+    public DashboardService(
+        IEmpresaRepository empresaRepository,
+        IUsuarioRepository usuarioRepository,
+        IConviteRepository conviteRepository,
+        IAuditRepository auditRepository)
+    {
+        _empresaRepository = empresaRepository;
+        _usuarioRepository = usuarioRepository;
+        _conviteRepository = conviteRepository;
+        _auditRepository = auditRepository;
+    }
+
+    public async Task<DashboardSummaryDTO> GetResumoAsync(Guid usuarioId)
+    {
+        var totalEmpresas = await _empresaRepository.CountByUsuarioId(usuarioId);
+        var totalUsuarios = await _usuarioRepository.CountClientesByContadorId(usuarioId);
+        var convitesPendentes = await _conviteRepository.CountPendentesByContadorId(usuarioId);
+
+        var atividadesRecentes = await _auditRepository.GetPagedAsync(new AuditLogFilterDTO
+        {
+            UsuarioId = usuarioId,
+            Pagina = 1,
+            TamanhoPagina = 5
+        });
+
+        return new DashboardSummaryDTO
+        {
+            TotalEmpresas = totalEmpresas,
+            TotalUsuarios = totalUsuarios,
+            ConvitesPendentes = convitesPendentes,
+            AtividadesRecentes = atividadesRecentes.Logs.ToList()
+        };
+    }
+}

--- a/src/TCC.Contabilidade.Infrastructure/Repositories/ConviteRepository.cs
+++ b/src/TCC.Contabilidade.Infrastructure/Repositories/ConviteRepository.cs
@@ -52,4 +52,11 @@ public class ConviteRepository : IConviteRepository
     {
         await _context.SaveChangesAsync();
     }
+
+    public async Task<int> CountPendentesByContadorId(Guid contadorId)
+    {
+        return await _context.Convites
+            .Where(c => c.ContadorId == contadorId && !c.Utilizado && c.Expiracao > DateTime.UtcNow)
+            .CountAsync();
+    }
 }

--- a/src/TCC.Contabilidade.Infrastructure/Repositories/EmpresaRepository.cs
+++ b/src/TCC.Contabilidade.Infrastructure/Repositories/EmpresaRepository.cs
@@ -83,4 +83,11 @@ public class EmpresaRepository : IEmpresaRepository
     {
         return await _context.UsuariosEmpresas.AnyAsync(ue => ue.UsuarioId == usuarioId && ue.EmpresaId == empresaId);
     }
+
+    public async Task<int> CountByUsuarioId(Guid usuarioId)
+    {
+        return await _context.UsuariosEmpresas
+            .Where(ue => ue.UsuarioId == usuarioId)
+            .CountAsync();
+    }
 }

--- a/src/TCC.Contabilidade.Infrastructure/Repositories/UsuarioRepository.cs
+++ b/src/TCC.Contabilidade.Infrastructure/Repositories/UsuarioRepository.cs
@@ -40,4 +40,11 @@ public class UsuarioRepository : IUsuarioRepository
     {
         await _context.SaveChangesAsync();
     }
+
+    public async Task<int> CountClientesByContadorId(Guid contadorId)
+    {
+        return await _context.Usuarios
+            .Where(u => u.ContadorId == contadorId)
+            .CountAsync();
+    }
 }


### PR DESCRIPTION
Este PR implementa o endpoint de resumo do dashboard conforme solicitado na issue #49.

Mudanças:
- Criado DashboardSummaryDTO com documentação Swagger.
- Adicionados métodos de contagem nos repositórios de Empresa, Usuário e Convite para otimizar a consulta de indicadores.
- Implementado DashboardService para consolidar os dados (total de empresas, clientes, convites pendentes e atividades recentes).
- Criado DashboardController com endpoint GET /api/Dashboard/resumo, restrito aos perfis Contador e Admin.
- Garantido isolamento de dados filtrando as atividades recentes pelo ID do usuário logado.

Closes #49

---
*PR created automatically by Jules for task [13753079101242065113](https://jules.google.com/task/13753079101242065113) started by @zzRonald*