### PR TITLE
Implement automatic overdue control for payment guides

### DIFF
--- a/src/TCC.Contabilidade.Application/DTO/DashboardSummaryDTO.cs
+++ b/src/TCC.Contabilidade.Application/DTO/DashboardSummaryDTO.cs
@@ -21,6 +21,11 @@ public class DashboardSummaryDTO
     public int ConvitesPendentes { get; set; }
 
     /// <summary>
+    /// Quantidade de guias de pagamento vencidas.
+    /// </summary>
+    public int GuiasVencidas { get; set; }
+
+    /// <summary>
     /// Lista das atividades recentes registradas na auditoria para o usuário.
     /// </summary>
     public List<AuditLogResponseDTO> AtividadesRecentes { get; set; } = new();

--- a/src/TCC.Contabilidade.Application/DTO/GuiaPagamentoDTO.cs
+++ b/src/TCC.Contabilidade.Application/DTO/GuiaPagamentoDTO.cs
@@ -35,6 +35,8 @@ public class GuiaPagamentoFilterDTO
     public int Pagina { get; set; } = 1;
     public int TamanhoPagina { get; set; } = 10;
     public Guid? CompetenciaId { get; set; }
+    public bool? ApenasVencidas { get; set; }
+    public bool? ApenasAVencer { get; set; }
 }
 
 public record UpdateGuiaPagamentoStatusRequestDTO(

--- a/src/TCC.Contabilidade.Application/Interfaces/IGuiaPagamentoRepository.cs
+++ b/src/TCC.Contabilidade.Application/Interfaces/IGuiaPagamentoRepository.cs
@@ -6,9 +6,16 @@ namespace TCC.Contabilidade.Application.Interfaces;
 public interface IGuiaPagamentoRepository
 {
     Task<GuiaPagamento?> ObterPorIdAsync(Guid id);
-    Task<(IEnumerable<GuiaPagamento> Itens, int Total)> ObterPaginadoAsync(Guid empresaId, int pagina, int tamanhoPagina, Guid? competenciaId = null);
+    Task<(IEnumerable<GuiaPagamento> Itens, int Total)> ObterPaginadoAsync(
+        Guid empresaId,
+        int pagina,
+        int tamanhoPagina,
+        Guid? competenciaId = null,
+        bool? apenasVencidas = null,
+        bool? apenasAVencer = null);
     Task AdicionarAsync(GuiaPagamento guia);
     Task AtualizarAsync(GuiaPagamento guia);
     Task RemoverAsync(GuiaPagamento guia);
     Task SalvarAlteracoesAsync();
+    Task<int> CountVencidasByUsuarioIdAsync(Guid usuarioId);
 }

--- a/src/TCC.Contabilidade.Application/Services/DashboardService.cs
+++ b/src/TCC.Contabilidade.Application/Services/DashboardService.cs
@@ -9,17 +9,20 @@ public class DashboardService : IDashboardService
     private readonly IUsuarioRepository _usuarioRepository;
     private readonly IConviteRepository _conviteRepository;
     private readonly IAuditRepository _auditRepository;
+    private readonly IGuiaPagamentoRepository _guiaPagamentoRepository;
 
     public DashboardService(
         IEmpresaRepository empresaRepository,
         IUsuarioRepository usuarioRepository,
         IConviteRepository conviteRepository,
-        IAuditRepository auditRepository)
+        IAuditRepository auditRepository,
+        IGuiaPagamentoRepository guiaPagamentoRepository)
     {
         _empresaRepository = empresaRepository;
         _usuarioRepository = usuarioRepository;
         _conviteRepository = conviteRepository;
         _auditRepository = auditRepository;
+        _guiaPagamentoRepository = guiaPagamentoRepository;
     }
 
     public async Task<DashboardSummaryDTO> GetResumoAsync(Guid usuarioId)
@@ -27,6 +30,7 @@ public class DashboardService : IDashboardService
         var totalEmpresas = await _empresaRepository.CountByUsuarioId(usuarioId);
         var totalUsuarios = await _usuarioRepository.CountClientesByContadorId(usuarioId);
         var convitesPendentes = await _conviteRepository.CountPendentesByContadorId(usuarioId);
+        var guiasVencidas = await _guiaPagamentoRepository.CountVencidasByUsuarioIdAsync(usuarioId);
 
         var atividadesRecentes = await _auditRepository.GetPagedAsync(new AuditLogFilterDTO
         {
@@ -40,6 +44,7 @@ public class DashboardService : IDashboardService
             TotalEmpresas = totalEmpresas,
             TotalUsuarios = totalUsuarios,
             ConvitesPendentes = convitesPendentes,
+            GuiasVencidas = guiasVencidas,
             AtividadesRecentes = atividadesRecentes.Logs.ToList()
         };
     }

--- a/src/TCC.Contabilidade.Application/Services/GuiaPagamentoService.cs
+++ b/src/TCC.Contabilidade.Application/Services/GuiaPagamentoService.cs
@@ -186,7 +186,9 @@ public class GuiaPagamentoService
             empresaId,
             filtros.Pagina,
             filtros.TamanhoPagina,
-            filtros.CompetenciaId);
+            filtros.CompetenciaId,
+            filtros.ApenasVencidas,
+            filtros.ApenasAVencer);
 
         var response = itens.Select(MapToResponse);
 
@@ -203,6 +205,9 @@ public class GuiaPagamentoService
 
     private static GuiaPagamentoResponseDTO MapToResponse(GuiaPagamento guia)
     {
+        bool estaVencida = (guia.Status != StatusGuia.Pago && guia.Status != StatusGuia.Cancelado) &&
+                           guia.DataVencimento < DateTime.UtcNow;
+
         return new GuiaPagamentoResponseDTO(
             guia.Id,
             guia.EmpresaId,
@@ -219,7 +224,7 @@ public class GuiaPagamentoService
             guia.DocumentoId,
             guia.ComprovanteId,
             guia.DataCriacao,
-            guia.DataVencimento < DateTime.UtcNow && guia.Status == StatusGuia.Pendente
+            estaVencida
         );
     }
 }

--- a/src/TCC.Contabilidade.Infrastructure/Repositories/GuiaPagamentoRepository.cs
+++ b/src/TCC.Contabilidade.Infrastructure/Repositories/GuiaPagamentoRepository.cs
@@ -23,7 +23,13 @@ public class GuiaPagamentoRepository : IGuiaPagamentoRepository
             .FirstOrDefaultAsync(g => g.Id == id);
     }
 
-    public async Task<(IEnumerable<GuiaPagamento> Itens, int Total)> ObterPaginadoAsync(Guid empresaId, int pagina, int tamanhoPagina, Guid? competenciaId = null)
+    public async Task<(IEnumerable<GuiaPagamento> Itens, int Total)> ObterPaginadoAsync(
+        Guid empresaId,
+        int pagina,
+        int tamanhoPagina,
+        Guid? competenciaId = null,
+        bool? apenasVencidas = null,
+        bool? apenasAVencer = null)
     {
         var query = _context.GuiasPagamento
             .Include(g => g.Competencia)
@@ -34,6 +40,21 @@ public class GuiaPagamentoRepository : IGuiaPagamentoRepository
         if (competenciaId.HasValue)
         {
             query = query.Where(g => g.CompetenciaId == competenciaId.Value);
+        }
+
+        var hoje = DateTime.UtcNow;
+
+        if (apenasVencidas == true)
+        {
+            query = query.Where(g => g.Status != TCC.Contabilidade.Domain.Enums.StatusGuia.Pago &&
+                                   g.Status != TCC.Contabilidade.Domain.Enums.StatusGuia.Cancelado &&
+                                   g.DataVencimento < hoje);
+        }
+        else if (apenasAVencer == true)
+        {
+            query = query.Where(g => g.Status != TCC.Contabilidade.Domain.Enums.StatusGuia.Pago &&
+                                   g.Status != TCC.Contabilidade.Domain.Enums.StatusGuia.Cancelado &&
+                                   g.DataVencimento >= hoje);
         }
 
         var total = await query.CountAsync();
@@ -66,5 +87,23 @@ public class GuiaPagamentoRepository : IGuiaPagamentoRepository
     public async Task SalvarAlteracoesAsync()
     {
         await _context.SaveChangesAsync();
+    }
+
+    public async Task<int> CountVencidasByUsuarioIdAsync(Guid usuarioId)
+    {
+        var hoje = DateTime.UtcNow;
+
+        return await _context.GuiasPagamento
+            .Join(_context.UsuariosEmpresas,
+                g => g.EmpresaId,
+                ue => ue.EmpresaId,
+                (g, ue) => new { Guia = g, UsuarioEmpresa = ue })
+            .Where(x => x.UsuarioEmpresa.UsuarioId == usuarioId &&
+                        x.Guia.Status != TCC.Contabilidade.Domain.Enums.StatusGuia.Pago &&
+                        x.Guia.Status != TCC.Contabilidade.Domain.Enums.StatusGuia.Cancelado &&
+                        x.Guia.DataVencimento < hoje)
+            .Select(x => x.Guia.Id)
+            .Distinct()
+            .CountAsync();
     }
 }


### PR DESCRIPTION
### What changed?
Implemented automatic identification of overdue payment guides (Guias) and added filtering capabilities for "Expired" and "Soon to Expire" guides. Integrated a new "Overdue Guides" indicator into the accountant's dashboard.

### Improvements:
- **Dynamic Expiration Logic:** Overdue status (EstaVencida) is now calculated on-the-fly based on DataVencimento and Status (excluding 'Pago' and 'Cancelado').
- **Advanced Filtering:** Added ApenasVencidas and ApenasAVencer filters to the payment guide list API.
- **Dashboard Integration:** Accountants can now see the total number of overdue guides across all their managed companies directly on the dashboard.
- **Optimized Repository Queries:** Implemented efficient EF Core queries for both filtered listings and cross-company overdue counts.

### Reasoning:
Calculating the "overdue" state dynamically ensures that the information is always accurate without relying on scheduled background jobs to update database flags. This approach improves system reliability and provides users with real-time financial indicators.

### Impact on Client/System:
Clients and accountants now have immediate visibility into pending financial obligations, helping to avoid late fees and improving financial management. The system becomes more robust by centralizing business rules for overdue statuses.

Closes #76

---
*PR created automatically by Jules for task [18285176599957602386](https://jules.google.com/task/18285176599957602386) started by @zzRonald*